### PR TITLE
Added get transactional event to acs client

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ const client = new ACSHttpClient({ orgId: "acme", orgInstanceId: "acme-mkt-stage
   });
   ```
 
+- getTransactionalEvent
+  Docs: https://docs.adobe.com/content/help/en/campaign-standard/using/working-with-apis/managing-transactional-messages.html#response-to-the-post-request
+
+  ```javascript
+  client.getTransactionalEvent("EVTTest", "adobe-event-pkey");
+  ```
+
 - sendTransactionalPushEvent
   Docs: https://docs.adobe.com/content/help/en/campaign-standard/using/communication-channels/transactional-messaging/transactional-push-notifications.html
   ```javascript

--- a/src/acs-http-client.ts
+++ b/src/acs-http-client.ts
@@ -60,6 +60,20 @@ export class ACSHttpClient {
   }
 
   /**
+   * https://docs.adobe.com/content/help/en/campaign-standard/using/working-with-apis/managing-transactional-messages.html#response-to-the-post-request
+   *
+   * @param eventId
+   * @param PKey
+   */
+  async getTransactionalEvent(eventId: string, PKey: string) {
+    const headers = await this.getAuthHeaders();
+    const { orgId, orgInstanceId } = this.config;
+
+    const url = `https://mc.adobe.io/${orgInstanceId}/campaign/mc${orgId}/${eventId}/${PKey}`;
+    return this.httpClient.get(url, { headers });
+  }
+
+  /**
    * https://docs.adobe.com/content/help/en/campaign-standard/using/communication-channels/transactional-messaging/transactional-push-notifications.html
    *
    * @param eventId


### PR DESCRIPTION
Closes: #413 

## What
- Added get the transactional event to acs client

## How
- Added `getTransactionalEvent` to make a GET HTTP request to the same endpoint as `sendTransactionalEvent` in `acs-client`

## REF
https://docs.adobe.com/content/help/en/campaign-standard/using/working-with-apis/managing-transactional-messages.html#response-to-the-post-request

#413 